### PR TITLE
Enable XML highlighting

### DIFF
--- a/ninja_ide/gui/editor/highlighter.py
+++ b/ninja_ide/gui/editor/highlighter.py
@@ -116,6 +116,7 @@ LEXER_MAP = {
     "rst": "rst",
     "c": "c",
     "java": "java",
+    "xml": "xml",
 }
 
 BUILT_LEXERS = {

--- a/ninja_ide/gui/ide.py
+++ b/ninja_ide/gui/ide.py
@@ -684,7 +684,7 @@ class IDE(QMainWindow):
     def _save_unsaved_files(self, files):
         """Save the files from the paths in the array."""
         for f in files:
-            editable = self.get_or_create_editable(f)
+            editable = self.get_or_create_editable(nfile=f)
             editable.ignore_checkers = True
             editable.save_content()
 


### PR DESCRIPTION
XML Lexer existed, but the "xml" extension was not enabled in LEXER_MAP.
